### PR TITLE
Remove Deface warning

### DIFF
--- a/app/overrides/views_override.rb
+++ b/app/overrides/views_override.rb
@@ -2,6 +2,5 @@ Deface::Override.new(
   virtual_path: "spree/admin/shared/sub_menu/_configuration",
   name: "mail_settings_admin_configurations_menu",
   insert_bottom: "[data-hook='admin_configurations_sidebar_menu']",
-  text: "<%= configurations_sidebar_menu_item Spree.t(:mail_method_settings), edit_admin_mail_method_url %>",
-  disabled: false
+  text: "<%= configurations_sidebar_menu_item Spree.t(:mail_method_settings), edit_admin_mail_method_url %>"
 )


### PR DESCRIPTION
Deface doesn't need this piece of code to work, it cares to autoload everything inside overrides
````ruby
    def self.activate
      Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
        Rails.application.config.cache_classes ? require(c) : load(c)
      end
    end

    config.to_prepare &method(:activate).to_proc
````
My reference:
https://github.com/spree/deface/issues/76