### PR TITLE
Add mails_from preference

### DIFF
--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -1,6 +1,7 @@
 module Spree
   AppConfiguration.class_eval do
     # Default mail headers settings
+    preference :mails_from, :string, default: 'spree@example.com'
     preference :enable_mail_delivery, :boolean, default: false
     preference :mail_bcc, :string, default: 'spree@example.com'
     preference :intercept_email, :string, default: nil


### PR DESCRIPTION
As noted in #9, `mails_from` don't have a default so it raises an exception when you install from scratch and go to mail_preferences settings.

This pull request adds the default preference.