### PR TITLE
Add preferred emails instead of defaulting to message.bcc

### DIFF
--- a/lib/spree/core/mail_interceptor.rb
+++ b/lib/spree/core/mail_interceptor.rb
@@ -15,9 +15,9 @@ module Spree
           if message.bcc.present?
             original_bcc = message.bcc.split(',').map(&:strip)
             prefered_bcc = Config[:mail_bcc].split(',').map(&:strip)
-            message.bcc = (original_bcc | prefered_bcc).join(", ")
+            message.bcc = (original_bcc | prefered_bcc).join(', ')
           else
-            message.bcc = Config[:mail_bcc] 
+            message.bcc = Config[:mail_bcc]
           end
         end
       end

--- a/lib/spree/core/mail_interceptor.rb
+++ b/lib/spree/core/mail_interceptor.rb
@@ -13,7 +13,12 @@ module Spree
 
         if Config[:mail_bcc].present?
           if message.bcc.present?
-            original_bcc = message.bcc.split(',').map(&:strip)
+            if message.bcc.respond_to?(:each)
+              original_bcc = message.bcc
+            else
+              original_bcc = message.bcc.split(',').map(&:strip)
+            end
+            
             prefered_bcc = Config[:mail_bcc].split(',').map(&:strip)
             message.bcc = (original_bcc | prefered_bcc).join(', ')
           else

--- a/lib/spree/core/mail_interceptor.rb
+++ b/lib/spree/core/mail_interceptor.rb
@@ -11,7 +11,15 @@ module Spree
           message.to = Config[:intercept_email]
         end
 
-        message.bcc ||= Config[:mail_bcc] if Config[:mail_bcc].present?
+        if Config[:mail_bcc].present?
+          if message.bcc.present?
+            original_bcc = message.bcc.split(',').map(&:strip)
+            prefered_bcc = Config[:mail_bcc].split(',').map(&:strip)
+            message.bcc = (original_bcc | prefered_bcc).join(", ")
+          else
+            message.bcc = Config[:mail_bcc] 
+          end
+        end
       end
     end
   end

--- a/lib/spree/core/mail_interceptor.rb
+++ b/lib/spree/core/mail_interceptor.rb
@@ -18,7 +18,7 @@ module Spree
             else
               original_bcc = message.bcc.split(',').map(&:strip)
             end
-            
+
             prefered_bcc = Config[:mail_bcc].split(',').map(&:strip)
             message.bcc = (original_bcc | prefered_bcc).join(', ')
           else


### PR DESCRIPTION
It is very counter intuitive to just default to bcc set in mailer. Especially in cases when it is necessary to set it up there for conditional mailing.

I would like to propose that, instead, BCCs should be added to already defined message.bcc.