### PR TITLE
bump version to 3.1.0, fix spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-spree_version = 'master'
+spree_version = '3-1-stable'
 gem 'spree', github: 'spree/spree', branch: spree_version
 gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: spree_version
 

--- a/lib/spree_mail_settings/version.rb
+++ b/lib/spree_mail_settings/version.rb
@@ -11,7 +11,7 @@ module SpreeMailSettings
     MAJOR = 3
     MINOR = 1
     TINY  = 0
-    PRE   = 'beta'
+    PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
   end

--- a/spec/lib/mail_interceptor_spec.rb
+++ b/spec/lib/mail_interceptor_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Spree::OrderMailer do
 
   context '#deliver' do
     before do
+      store.send(:clear_cache)
       ActionMailer::Base.delivery_method = :test
       Spree::Config[:intercept_email] = ''
     end


### PR DESCRIPTION
- Bump version to 3.1.0
- Change spree branch to 3-1-stable
- Fix spec - clear store cache to fetch current store