### PR TITLE
bump version to 3.2.0.alpha

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-spree_version = '3-1-stable'
+spree_version = 'master'
 gem 'spree', github: 'spree/spree', branch: spree_version
 gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: spree_version
 

--- a/lib/spree_mail_settings/version.rb
+++ b/lib/spree_mail_settings/version.rb
@@ -9,9 +9,9 @@ module SpreeMailSettings
 
   module VERSION
     MAJOR = 3
-    MINOR = 1
+    MINOR = 2
     TINY  = 0
-    PRE   = nil
+    PRE   = 'alpha'.freeze
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
   end

--- a/spree_mail_settings.gemspec
+++ b/spree_mail_settings.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_runtime_dependency 'spree_backend', '~> 3.1.0.beta'
+  s.add_runtime_dependency 'spree_backend', '~> 3.2.0.alpha'
 
   s.add_development_dependency 'capybara', '~> 2.4'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
- bump version to 3.2.0.alpha
- change spree_backend dependency version to 3.2.0.alpha
- change spree branch to master