### PR TITLE
Set spree_backend to >= 3.1.0 and < 4.0 version

### DIFF
--- a/spree_mail_settings.gemspec
+++ b/spree_mail_settings.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_runtime_dependency 'spree_backend', '~> 3.2.0.alpha'
+  s.add_runtime_dependency 'spree_backend', '>= 3.1.0', '< 4.0'
 
   s.add_development_dependency 'capybara', '~> 2.4'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
This PR changes the version of `spree_backend` in gemspec to point at `>= 3.1.0` and `< 4.0`.