### PR TITLE
Fix for gmail accounts

### DIFF
--- a/lib/spree/core/mail_settings.rb
+++ b/lib/spree/core/mail_settings.rb
@@ -21,7 +21,7 @@ module Spree
 
         if secure_connection?
           settings[:enable_starttls_auto] = true
-          settings[:tls] = true
+          settings[:tls] = (!Config.mail_host.include? "gmail")
         end
         settings
       end


### PR DESCRIPTION
PR #39 Broke the ability to use Gmail accounts with this gem. Gmail accounts should always default to TLS = false. This PR sets TLS = False for gmail accounts and true for all others.